### PR TITLE
Implement input parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Features
+
+-   Implemented the `input` function.
+
+<!-- scaffolded by git-cliff -->

--- a/src/gparsec.gleam
+++ b/src/gparsec.gleam
@@ -1,3 +1,25 @@
-pub fn placeholder() {
-  "placeholder"
+import gleam/string
+
+pub type ParserPosition {
+  ParserPosition(row: Int, col: Int)
+}
+
+pub type Parser(a) {
+  Parser(tokens: List(String), pos: ParserPosition, value: a)
+}
+
+pub type ParserFailure {
+  UnexpectedToken(
+    expected_tokens: List(String),
+    actual_token: String,
+    pos: ParserPosition,
+  )
+  UnexpectedEof(expected_tokens: List(String), pos: ParserPosition)
+}
+
+pub type ParserResult(a) =
+  Result(Parser(a), ParserFailure)
+
+pub fn input(tokens tokens: String, initial_value value: a) -> ParserResult(a) {
+  Ok(Parser(tokens |> string.split(""), ParserPosition(0, 0), value))
 }

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -1,14 +1,17 @@
-import gparsec
-import startest.{it}
+import gparsec.{Parser, ParserPosition}
+import startest.{describe, it}
 import startest/expect
 
 pub fn main() {
   startest.run(startest.default_config())
 }
 
-pub fn placeholder_tests() {
-  it("returns \"placeholder\"", fn() {
-    gparsec.placeholder()
-    |> expect.to_equal("placeholder")
-  })
+pub fn input_tests() {
+  describe("gparsec/input", [
+    it("returns a new parser", fn() {
+      gparsec.input(tokens: "abc", initial_value: [])
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["a", "b", "c"], ParserPosition(0, 0), []))
+    }),
+  ])
 }


### PR DESCRIPTION
# Pull Request

Issue: #1 

## Description

This PR implements the `input` function, which can be used to create a new parser with a given set of unprocessed tokens.
