### PR TITLE
Implement optional parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
--   Implemented the `tokens` function.
+-   Implemented the `optional` function.
+-   Implemented the `token` function.
 -   Implemented the `input` function.
 
 <!-- scaffolded by git-cliff -->

--- a/src/gparsec.gleam
+++ b/src/gparsec.gleam
@@ -24,6 +24,9 @@ pub type ParserResult(a) =
 pub type ParserMapperCallback(a, b) =
   fn(a, b) -> a
 
+pub type ParserCombinatorCallback(a) =
+  fn(ParserResult(a)) -> ParserResult(a)
+
 pub fn ignore_token(value: a, _: String) -> a {
   value
 }
@@ -51,6 +54,16 @@ pub fn token(
     token_parser.pos,
     to(previous_parser.value, token_parser.value),
   ))
+}
+
+pub fn optional(
+  prev: ParserResult(a),
+  parser: ParserCombinatorCallback(a),
+) -> ParserResult(a) {
+  case parser(prev) {
+    Error(_) -> prev
+    Ok(parser) -> Ok(parser)
+  }
 }
 
 fn token_internal(

--- a/src/gparsec.gleam
+++ b/src/gparsec.gleam
@@ -24,7 +24,7 @@ pub type ParserResult(a) =
 pub type ParserMapperCallback(a, b) =
   fn(a, b) -> a
 
-pub fn ignore_tokens(value: a, _: String) -> a {
+pub fn ignore_token(value: a, _: String) -> a {
   value
 }
 
@@ -32,14 +32,14 @@ pub fn input(tokens: String, initial_value: a) -> ParserResult(a) {
   Ok(Parser(tokens |> string.split(""), ParserPosition(0, 0), initial_value))
 }
 
-pub fn tokens(
+pub fn token(
   prev: ParserResult(a),
   tokens: String,
   to: ParserMapperCallback(a, String),
 ) -> ParserResult(a) {
   use previous_parser <- result.try(prev)
 
-  use token_parser <- result.try(tokens_internal(
+  use token_parser <- result.try(token_internal(
     Ok(Parser(previous_parser.tokens, previous_parser.pos, "")),
     tokens |> string.split(""),
     "",
@@ -53,7 +53,7 @@ pub fn tokens(
   ))
 }
 
-fn tokens_internal(
+fn token_internal(
   prev: ParserResult(String),
   unprocessed_tokens: List(String),
   processed_tokens: String,
@@ -63,7 +63,7 @@ fn tokens_internal(
     [] -> prev
     [c, ..rest] ->
       single_token(prev, c, processed_tokens, expected_tokens)
-      |> tokens_internal(rest, processed_tokens <> c, expected_tokens)
+      |> token_internal(rest, processed_tokens <> c, expected_tokens)
   }
 }
 

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -17,10 +17,10 @@ pub fn input_tests() {
 }
 
 pub fn token_tests() {
-  describe("gparsec/tokens", [
+  describe("gparsec/token", [
     it("returns a parser that parsed a single token", fn() {
       gparsec.input("abc", "Characters: ")
-      |> gparsec.tokens("a", fn(value, token) { value <> token })
+      |> gparsec.token("a", fn(value, token) { value <> token })
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(
         ["b", "c"],
@@ -30,8 +30,8 @@ pub fn token_tests() {
     }),
     it("returns a parser that parsed a set of tokens", fn() {
       gparsec.input("abcdefg", "Characters: ")
-      |> gparsec.tokens("abc", fn(value, tokens) { value <> tokens })
-      |> gparsec.tokens("def", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("abc", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("def", fn(value, tokens) { value <> tokens })
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(
         ["g"],
@@ -41,21 +41,21 @@ pub fn token_tests() {
     }),
     it("returns a parser with a position that detected line breaks", fn() {
       gparsec.input("abc\ndef", "Characters: ")
-      |> gparsec.tokens("abc", fn(value, tokens) { value <> tokens })
-      |> gparsec.tokens("\n", gparsec.ignore_tokens)
-      |> gparsec.tokens("def", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("abc", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("\n", gparsec.ignore_token)
+      |> gparsec.token("def", fn(value, tokens) { value <> tokens })
       |> expect.to_be_ok()
       |> expect.to_equal(Parser([], ParserPosition(1, 3), "Characters: abcdef"))
     }),
     it("returns an error when encountering an unexpected token", fn() {
       gparsec.input("abcd", "")
-      |> gparsec.tokens("abdz", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("abdz", fn(value, tokens) { value <> tokens })
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedToken(["abdz"], "abc", ParserPosition(0, 2)))
     }),
     it("returns an error when encountering an unexpected EOF", fn() {
       gparsec.input("abc", "")
-      |> gparsec.tokens("abcd", fn(value, tokens) { value <> tokens })
+      |> gparsec.token("abcd", fn(value, tokens) { value <> tokens })
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedEof(["abcd"], ParserPosition(0, 3)))
     }),


### PR DESCRIPTION
# Pull Request

Issue: #3 

## Description

This PR implements the `optional` function, which takes another parser callback as an argument. The given parser will be executed and returned if it succeeds, otherwise, the previous parser will be returned. Effectively ignoring the error.
