### PR TITLE
Implement many parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `many` function.
 -   Implemented the `optional` function.
 -   Implemented the `token` function.
 -   Implemented the `input` function.

--- a/src/gparsec.gleam
+++ b/src/gparsec.gleam
@@ -66,6 +66,16 @@ pub fn optional(
   }
 }
 
+pub fn many(
+  prev: ParserResult(a),
+  parser: ParserCombinatorCallback(a),
+) -> ParserResult(a) {
+  case parser(prev) {
+    Error(_) -> prev
+    result -> many(result, parser)
+  }
+}
+
 fn token_internal(
   prev: ParserResult(String),
   unprocessed_tokens: List(String),

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -108,6 +108,39 @@ pub fn optional_tests() {
   ])
 }
 
+pub fn many_tests() {
+  describe("gparsec/many", [
+    it("returns a parser that parsed multiple tokens", fn() {
+      gparsec.input("aaab", "Characters: ")
+      |> gparsec.many(gparsec.token(_, "a", fn(value, token) { value <> token }))
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), "Characters: aaa"))
+    }),
+    it("returns a parser that parsed no tokens", fn() {
+      gparsec.input("abab", "Characters: ")
+      |> gparsec.many(gparsec.token(
+        _,
+        "aa",
+        fn(value, token) { value <> token },
+      ))
+      |> gparsec.token("ab", fn(value, token) { value <> token })
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(
+        ["a", "b"],
+        ParserPosition(0, 2),
+        "Characters: ab",
+      ))
+    }),
+    it("returns an error when a prior parser failed", fn() {
+      gparsec.input("aaa", "Characters: ")
+      |> gparsec.token("ab", fn(value, token) { value <> token })
+      |> gparsec.many(gparsec.token(_, "a", fn(value, token) { value <> token }))
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedToken(["ab"], "aa", ParserPosition(0, 1)))
+    }),
+  ])
+}
+
 type Pair {
   Pair(left: String, right: String)
 }


### PR DESCRIPTION
# Pull Request

Issue: #4 

## Description

This PR implements the `many` function, which takes a parser as an argument and applies it zero to n times.
