### PR TITLE
Implement skip_until parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `skip_until` function.
+-   Implemented the `until` function.
 -   Implemented the `integer` function.
 -   Implemented the `many` function.
 -   Implemented the `optional` function.

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -278,6 +278,46 @@ pub fn until_tests() {
   ])
 }
 
+pub fn skip_until_tests() {
+  describe("gparsec/skip_until", [
+    it(
+      "returns a parser that skipped all tokens until finding the equal sign",
+      fn() {
+        gparsec.input("let test = \"value\";", "")
+        |> gparsec.skip_until("=")
+        |> expect.to_be_ok()
+        |> expect.to_equal(Parser(
+          ["=", " ", "\"", "v", "a", "l", "u", "e", "\"", ";"],
+          ParserPosition(0, 9),
+          "",
+        ))
+      },
+    ),
+    it(
+      "returns a parser that skipped all tokens until finding the EQUALS word",
+      fn() {
+        gparsec.input("var test EQUALS something", "")
+        |> gparsec.skip_until("EQUALS")
+        |> expect.to_be_ok()
+        |> expect.to_equal(Parser(
+          [
+            "E", "Q", "U", "A", "L", "S", " ", "s", "o", "m", "e", "t", "h", "i",
+            "n", "g",
+          ],
+          ParserPosition(0, 9),
+          "",
+        ))
+      },
+    ),
+    it("returns an error when the until token could not be found", fn() {
+      gparsec.input("let test value;", "")
+      |> gparsec.skip_until("=")
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedEof("=", ParserPosition(0, 15)))
+    }),
+  ])
+}
+
 type Pair {
   Pair(left: String, right: String)
 }


### PR DESCRIPTION
# Pull Request

Issue: #8 

## Description

This PR implements the `skip_until` parser function, which skips all tokens until finding the expected token (exclusive).
