### PR TITLE
Implement repeat parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `repeat` function.
 -   Implemented the `skip_until` function.
 -   Implemented the `until` function.
 -   Implemented the `integer` function.

--- a/gleam.toml
+++ b/gleam.toml
@@ -19,3 +19,4 @@ gleam_stdlib = ">= 0.37.0 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.2.4 and < 2.0.0"
+simplifile = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -25,4 +25,5 @@ packages = [
 
 [requirements]
 gleam_stdlib = { version = ">= 0.37.0 and < 2.0.0" }
+simplifile = { version = "~> 1.0" }
 startest = { version = ">= 0.2.4 and < 2.0.0" }

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -1,0 +1,82 @@
+import gparsec.{type ParserResult}
+import simplifile
+import startest.{describe, it}
+import startest/expect
+
+/// CSV Data Format
+/// 
+/// Invoice No.;Recipient;Total
+/// 
+/// Int;String;Int
+///
+/// The parser needs to be able to parse and collect all invoices.
+pub fn csv_tests() {
+  describe("examples/csv_test", [
+    describe("invoices.csv", [
+      it("returns all invoices that are part of the CSV file", fn() {
+        let assert Ok(csv_content) =
+          simplifile.read("./test/examples/invoices.csv")
+
+        let parser =
+          gparsec.input(csv_content, [])
+          |> parse_invoices()
+          |> expect.to_be_ok()
+
+        parser.value
+        |> expect.to_equal([
+          Invoice(number: 10, recipient: "Jacob", total: 9),
+          Invoice(number: 8, recipient: "Tim", total: 120),
+          Invoice(number: 5, recipient: "Maria", total: 29),
+          Invoice(number: 1, recipient: "John", total: 250),
+        ])
+      }),
+    ]),
+  ])
+}
+
+type Invoice {
+  Invoice(number: Int, recipient: String, total: Int)
+}
+
+fn create_blank_invoice() -> Invoice {
+  Invoice(0, "", 0)
+}
+
+fn parse_invoices(
+  prev: ParserResult(List(Invoice)),
+) -> ParserResult(List(Invoice)) {
+  prev
+  |> skip_header()
+  |> gparsec.repeat(create_blank_invoice(), parse_invoice)
+}
+
+fn skip_header(prev: ParserResult(List(Invoice))) -> ParserResult(List(Invoice)) {
+  prev |> gparsec.skip_until("\n") |> gparsec.token("\n", gparsec.ignore_token)
+}
+
+fn parse_invoice(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
+  prev
+  |> parse_invoice_number()
+  |> parse_invoice_recipient()
+  |> parse_invoice_total()
+}
+
+fn parse_invoice_number(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
+  prev
+  |> gparsec.integer(fn(invoice, number) { Invoice(..invoice, number: number) })
+  |> gparsec.token(";", gparsec.ignore_token)
+}
+
+fn parse_invoice_recipient(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
+  prev
+  |> gparsec.until(";", fn(invoice, recipient) {
+    Invoice(..invoice, recipient: recipient)
+  })
+  |> gparsec.token(";", gparsec.ignore_token)
+}
+
+fn parse_invoice_total(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
+  prev
+  |> gparsec.integer(fn(invoice, total) { Invoice(..invoice, total: total) })
+  |> gparsec.token("\n", gparsec.ignore_token)
+}

--- a/test/examples/invoices.csv
+++ b/test/examples/invoices.csv
@@ -1,0 +1,5 @@
+Invoice No.;Recipient;Total
+1;John;250
+5;Maria;29
+8;Tim;120
+10;Jacob;9

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -318,6 +318,43 @@ pub fn skip_until_tests() {
   ])
 }
 
+pub fn repeat_tests() {
+  describe("gparsec/repeat", [
+    it("returns a parser that parsed multiple tokens", fn() {
+      gparsec.input("aaab", [])
+      |> gparsec.repeat("", gparsec.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), ["a", "a", "a"]))
+    }),
+    it("returns a parser that parsed no tokens", fn() {
+      gparsec.input("abab", [])
+      |> gparsec.repeat("", gparsec.token(
+        _,
+        "aa",
+        fn(value, token) { value <> token },
+      ))
+      |> gparsec.token("ab", fn(value, token) { [token, ..value] })
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["a", "b"], ParserPosition(0, 2), ["ab"]))
+    }),
+    it("returns an error when a prior parser failed", fn() {
+      gparsec.input("aaa", [])
+      |> gparsec.token("ab", fn(value, token) { [token, ..value] })
+      |> gparsec.repeat("", gparsec.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedToken("ab", "aa", ParserPosition(0, 1)))
+    }),
+  ])
+}
+
 type Pair {
   Pair(left: String, right: String)
 }


### PR DESCRIPTION
# Pull Request

Issue: #19 

## Description

This PR implements the `repeat` parser function and also provides a test suite showcasing how to parse a simple CSV format.
