### PR TITLE
Implement float parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `float` function.
 -   Implemented the `repeat` function.
 -   Implemented the `skip_until` function.
 -   Implemented the `until` function.

--- a/src/gparsec.gleam
+++ b/src/gparsec.gleam
@@ -98,38 +98,42 @@ pub fn integer(
   use previous_parser <- result.try(prev)
 
   use integer_parser <- result.try(case previous_parser.tokens {
-    [c, ..rest]
-      if c == "0"
-      || c == "1"
-      || c == "2"
-      || c == "3"
-      || c == "4"
-      || c == "5"
-      || c == "6"
-      || c == "7"
-      || c == "8"
-      || c == "9"
+    [token, ..rest]
+      if token == "0"
+      || token == "1"
+      || token == "2"
+      || token == "3"
+      || token == "4"
+      || token == "5"
+      || token == "6"
+      || token == "7"
+      || token == "8"
+      || token == "9"
     ->
       do_integer(
-        Ok(Parser(rest, increment_parser_position(previous_parser.pos, c), c)),
+        Ok(Parser(
+          rest,
+          increment_parser_position(previous_parser.pos, token),
+          token,
+        )),
       )
-    ["-", ..rest] ->
+    [token, ..rest] if token == "+" || token == "-" ->
       case rest {
         [] ->
           Error(UnexpectedEof(
             Digit,
-            increment_parser_position(previous_parser.pos, "-"),
+            increment_parser_position(previous_parser.pos, token),
           ))
         tokens ->
           do_integer(
             Ok(Parser(
               tokens,
-              increment_parser_position(previous_parser.pos, "-"),
-              "-",
+              increment_parser_position(previous_parser.pos, token),
+              token,
             )),
           )
       }
-    [c, ..] -> Error(UnexpectedToken(Digit, c, previous_parser.pos))
+    [token, ..] -> Error(UnexpectedToken(Digit, token, previous_parser.pos))
     [] -> Error(UnexpectedEof(Digit, previous_parser.pos))
   })
 
@@ -173,19 +177,19 @@ pub fn float(
         )),
         False,
       )
-    ["-", ..rest] ->
+    [token, ..rest] if token == "+" || token == "-" ->
       case rest {
         [] ->
           Error(UnexpectedEof(
             DigitOrDecimalPoint,
-            increment_parser_position(previous_parser.pos, "-"),
+            increment_parser_position(previous_parser.pos, token),
           ))
         tokens ->
           do_float(
             Ok(Parser(
               tokens,
-              increment_parser_position(previous_parser.pos, "-"),
-              "-",
+              increment_parser_position(previous_parser.pos, token),
+              token,
             )),
             False,
           )

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -5,9 +5,9 @@ import startest/expect
 
 /// CSV Data Format
 /// 
-/// Invoice No.;Recipient;Total
+/// Invoice No.,Recipient,Total
 /// 
-/// Int;String;Int
+/// Int,String,Float
 ///
 /// The parser needs to be able to parse and collect all invoices.
 pub fn csv_tests() {
@@ -24,10 +24,10 @@ pub fn csv_tests() {
 
         parser.value
         |> expect.to_equal([
-          Invoice(number: 10, recipient: "Jacob", total: 9),
-          Invoice(number: 8, recipient: "Tim", total: 120),
-          Invoice(number: 5, recipient: "Maria", total: 29),
-          Invoice(number: 1, recipient: "John", total: 250),
+          Invoice(number: 10, recipient: "Jacob", total: 9.99),
+          Invoice(number: 8, recipient: "Tim", total: 120.49),
+          Invoice(number: 5, recipient: "Maria", total: 29.9),
+          Invoice(number: 1, recipient: "John", total: 250.0),
         ])
       }),
     ]),
@@ -35,11 +35,11 @@ pub fn csv_tests() {
 }
 
 type Invoice {
-  Invoice(number: Int, recipient: String, total: Int)
+  Invoice(number: Int, recipient: String, total: Float)
 }
 
 fn create_blank_invoice() -> Invoice {
-  Invoice(0, "", 0)
+  Invoice(0, "", 0.0)
 }
 
 fn parse_invoices(
@@ -64,19 +64,19 @@ fn parse_invoice(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
 fn parse_invoice_number(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
   prev
   |> gparsec.integer(fn(invoice, number) { Invoice(..invoice, number: number) })
-  |> gparsec.token(";", gparsec.ignore_token)
+  |> gparsec.token(",", gparsec.ignore_token)
 }
 
 fn parse_invoice_recipient(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
   prev
-  |> gparsec.until(";", fn(invoice, recipient) {
+  |> gparsec.until(",", fn(invoice, recipient) {
     Invoice(..invoice, recipient: recipient)
   })
-  |> gparsec.token(";", gparsec.ignore_token)
+  |> gparsec.token(",", gparsec.ignore_token)
 }
 
 fn parse_invoice_total(prev: ParserResult(Invoice)) -> ParserResult(Invoice) {
   prev
-  |> gparsec.integer(fn(invoice, total) { Invoice(..invoice, total: total) })
+  |> gparsec.float(fn(invoice, total) { Invoice(..invoice, total: total) })
   |> gparsec.token("\n", gparsec.ignore_token)
 }

--- a/test/examples/invoices.csv
+++ b/test/examples/invoices.csv
@@ -1,5 +1,5 @@
-Invoice No.;Recipient;Total
-1;John;250
-5;Maria;29
-8;Tim;120
-10;Jacob;9
+Invoice No.,Recipient,Total
+1,John,250.0
+5,Maria,29.90
+8,Tim,120.49
+10,Jacob,9.99

--- a/test/gparsec_test.gleam
+++ b/test/gparsec_test.gleam
@@ -160,6 +160,15 @@ pub fn integer_tests() {
       |> expect.to_be_ok()
       |> expect.to_equal(Parser([], ParserPosition(0, 3), 250))
     }),
+    it(
+      "returns a parser that parsed a positive integer with an explicit sign",
+      fn() {
+        gparsec.input("+120", 0)
+        |> gparsec.integer(fn(_, integer) { integer })
+        |> expect.to_be_ok()
+        |> expect.to_equal(Parser([], ParserPosition(0, 4), 120))
+      },
+    ),
     it("returns a parser that parsed a negative integer", fn() {
       gparsec.input("-75", 0)
       |> gparsec.integer(fn(_, integer) { integer })
@@ -239,6 +248,15 @@ pub fn float_tests() {
       |> expect.to_be_ok()
       |> expect.to_equal(Parser([], ParserPosition(0, 5), 250.0))
     }),
+    it(
+      "returns a parser that parsed a positive float with an explicit sign",
+      fn() {
+        gparsec.input("+20.4", 0.0)
+        |> gparsec.float(fn(_, float) { float })
+        |> expect.to_be_ok()
+        |> expect.to_equal(Parser([], ParserPosition(0, 5), 20.4))
+      },
+    ),
     it("returns a parser that parsed a negative float", fn() {
       gparsec.input("-75.5", 0.0)
       |> gparsec.float(fn(_, float) { float })
@@ -277,7 +295,7 @@ pub fn float_tests() {
       },
     ),
     it(
-      "returns a parser that parsed a float and ignored everything after the second fraction token",
+      "returns a parser that parsed a float and ignored everything after the second decimal point",
       fn() {
         gparsec.input("25.5.1", 0.0)
         |> gparsec.float(fn(_, float) { float })


### PR DESCRIPTION
# Pull Request

Issue: #6 

## Description

This PR implements the `float` parser function, which can be used to parse floats. The parser also supports floats without an integral part (e.g., `.2`, `-.5`, or `+.1`) by adding an integral part equal to zero in such cases. Some additional changes include refined error reporting.